### PR TITLE
Adding new EntryPoint label + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This is a sample SF enabled service showing the currently supported labels. If t
         <Extension Name="traefik">
         <Labels xmlns="http://schemas.microsoft.com/2015/03/fabact-no-schema">
           <Label Key="traefik.http.enable">true</Label>
+          <Label Key="traefik.http.entrypoints">web</Label>
           <Label Key="traefik.http.loadbalancer.passhostheader">true</Label>
           <Label Key="traefik.http.loadbalancer.healthcheck.path">/</Label>
           <Label Key="traefik.http.loadbalancer.healthcheck.interval">10s</Label>
@@ -69,6 +70,10 @@ This is a sample SF enabled service showing the currently supported labels. If t
 ```
 
 ## Supported Labels (since 0.2.x) ##
+
+*Entrypoints section*
+* **traefik.http.entrypoints** Comma separated list of entrypoints to be assigned to router, e.g., Web, WebSecure.
+
 *Rule section*
 * **traefik.http.rule**    Traefik rule to apply [PathPrefix(`/dario`))]. This rule is added on top of the default path generation. If this is set, you **have** to define a middleware to remove the prefix for the service to receive the stripped path.
 

--- a/serviceFabricPlugin.go
+++ b/serviceFabricPlugin.go
@@ -366,7 +366,7 @@ func (p *Provider) generateConfiguration(e []ServiceItemExtended) *dynamic.Confi
 		baseName = normalize(baseName)
 		var baseRouter *dynamic.Router = nil
 
-		entryPoints := strings.Split(GetStringValue(i.Labels, traefikSFEntryPoints, "web"), ",")
+		entryPoints := strings.Split(strings.TrimSpace(GetStringValue(i.Labels, traefikSFEntryPoints, "web")), ",")
 
 		// If there is only one partition, expose the service name route directly
 		if len(i.Partitions) == 1 {

--- a/serviceFabricPlugin.go
+++ b/serviceFabricPlugin.go
@@ -19,6 +19,7 @@ import (
 const (
 	traefikServiceFabricExtensionKey     = "Traefik"
 	traefikSFEnableService               = "traefik.http.enable"
+	traefikSFEntryPoints                 = "traefik.http.entrypoints"
 	traefikSFRule                        = "traefik.http.rule"
 	traefikSFEnableLabelOverrides        = "Traefik.enablelabeloverrides"
 	traefikSFEnableLabelOverridesDefault = true
@@ -365,16 +366,18 @@ func (p *Provider) generateConfiguration(e []ServiceItemExtended) *dynamic.Confi
 		baseName = normalize(baseName)
 		var baseRouter *dynamic.Router = nil
 
+		entryPoints := strings.Split(GetStringValue(i.Labels, traefikSFEntryPoints, "web"), ",")
+
 		// If there is only one partition, expose the service name route directly
 		if len(i.Partitions) == 1 {
 			baseRouter = &dynamic.Router{
-				EntryPoints: []string{"web"},
+				EntryPoints: entryPoints,
 				Service:     baseName,
 				Middlewares: []string{},
 			}
 
 			// If a rule is explicitly provided, use it as is.
-			// Is the user responsibility in this case to add a matching stript middleware.
+			// Is the user responsibility in this case to add a matching strip middleware.
 			if r := GetStringValue(i.Labels, traefikSFRule, ""); r != "" {
 				baseRouter.Rule = r
 			} else {
@@ -392,7 +395,7 @@ func (p *Provider) generateConfiguration(e []ServiceItemExtended) *dynamic.Confi
 			rule := fmt.Sprintf("PathPrefix(`/%s/%s`)", i.ID, partitionID)
 
 			router := &dynamic.Router{
-				EntryPoints: []string{"web"},
+				EntryPoints: entryPoints,
 				Service:     name,
 				Rule:        rule,
 				Middlewares: []string{},


### PR DESCRIPTION
Added support for customising the entrypoint(s) within the SF Service Manifest. Resolves #7 