### PR TITLE
Fixed sticky sessions and added sticky session settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ This is a sample SF enabled service showing the currently supported labels. If t
           <Label Key="traefik.http.loadbalancer.healthcheck.path">/</Label>
           <Label Key="traefik.http.loadbalancer.healthcheck.interval">10s</Label>
           <Label Key="traefik.http.loadbalancer.healthcheck.scheme">http</Label>
+          <Label Key="traefik.http.loadbalancer.stickiness">true</Label>
+          <Label Key="traefik.http.loadbalancer.stickiness.secure">true</Label>
+          <Label Key="traefik.http.loadbalancer.stickiness.httpOnly">true</Label>
+          <Label Key="traefik.http.loadbalancer.stickiness.sameSite">none</Label>
+          <Label Key="traefik.http.loadbalancer.stickiness.cookieName">stickycookie</Label>
         </Labels>
         </Extension>
       </Extensions>

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ This is a sample SF enabled service showing the currently supported labels. If t
 * **traefik.http.loadbalancer.healthcheck.path**        Healthcheck endpoint path ['/healtz']
 * **traefik.http.loadbalancer.healthcheck.interval**    Healthcheck interval ['10s']
 * **traefik.http.loadbalancer.healthcheck.scheme**      Healthcheck scheme ['http']
+* **traefik.http.loadbalancer.stickiness**      Enable sticky sessions ['true'/'false']
+* **traefik.http.loadbalancer.stickiness.secure**      Enable Secure flag for sticky session cookie ['true'/'false']
+* **traefik.http.loadbalancer.stickiness.httpOnly**      Enable HTTPOnly flag for sticky session cookie ['true'/'false']
+* **traefik.http.loadbalancer.stickiness.sameSite**      Enable SameSite flag for sticky session cookie ['none'/'lax'/'strict']
+* **traefik.http.loadbalancer.stickiness.cookieName**      Enable static name for sticky session cookie ['stickycookie']
 
 *Middleware section*
 * **traefik.http.middleware.stripprefix**    prefix to strip ['/dario']

--- a/labels.go
+++ b/labels.go
@@ -56,8 +56,10 @@ func setLoadbalancerSticky(lb *dynamic.ServersLoadBalancer, val string) error {
 		v = false
 	}
 
+	// Stickiness requires element "Sticky" and under that element "Cookie".
 	if v {
 		lb.Sticky = &dynamic.Sticky{}
+		lb.Sticky.Cookie = &dynamic.Cookie{}
 	}
 	return nil
 }

--- a/labels.go
+++ b/labels.go
@@ -3,6 +3,7 @@ package traefikServiceFabricPlugin
 import (
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/traefik/genconf/dynamic"
 )
@@ -98,7 +99,15 @@ func setLoadbalancerStickySameSite(lb *dynamic.ServersLoadBalancer, val string) 
 	if lb.Sticky == nil {
 		lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
 	}
-	lb.Sticky.Cookie.SameSite = val
+	
+	// Value must be "none", "lax", or "strict".
+	valid := map[string]bool{"none": true, "lax": true, "strict": true}
+    if valid[strings.ToLower(val)] {
+		lb.Sticky.Cookie.SameSite = val
+	} else {
+		log.Printf("Unrecognised value '%s' provided for Cookie.SameSite", val)
+		return nil
+	}
 	return nil
 }
 

--- a/labels.go
+++ b/labels.go
@@ -56,13 +56,60 @@ func setLoadbalancerSticky(lb *dynamic.ServersLoadBalancer, val string) error {
 		v = false
 	}
 
-	// Stickiness requires element "Sticky" and under that element "Cookie".
 	if v {
-		lb.Sticky = &dynamic.Sticky{}
-		lb.Sticky.Cookie = &dynamic.Cookie{}
+		if lb.Sticky == nil {
+			lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+		}
 	}
 	return nil
 }
+
+func setLoadbalancerStickySecure(lb *dynamic.ServersLoadBalancer, val string) error {
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		v = false
+	}
+
+	if v {
+		if lb.Sticky == nil {
+			lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+		}
+		lb.Sticky.Cookie.Secure = v
+	}
+	return nil
+}
+
+func setLoadbalancerStickyHttpOnly(lb *dynamic.ServersLoadBalancer, val string) error {
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		v = false
+	}
+
+	if v {
+		if lb.Sticky == nil {
+			lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+		}
+		lb.Sticky.Cookie.HTTPOnly = v
+	}
+	return nil
+}
+
+func setLoadbalancerStickySameSite(lb *dynamic.ServersLoadBalancer, val string) error {
+	if lb.Sticky == nil {
+		lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+	}
+	lb.Sticky.Cookie.SameSite = val
+	return nil
+}
+
+func setLoadbalancerStickyCookieName(lb *dynamic.ServersLoadBalancer, val string) error {
+	if lb.Sticky == nil {
+		lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+	}
+	lb.Sticky.Cookie.Name = val
+	return nil
+}
+
 
 func setLoadbalancerHealthcheckPath(lb *dynamic.ServersLoadBalancer, val string) error {
 	if lb.HealthCheck == nil {

--- a/labels.go
+++ b/labels.go
@@ -51,6 +51,10 @@ func setLoadbalancerPasshostheader(lb *dynamic.ServersLoadBalancer, val string) 
 	return nil
 }
 
+func newSticky() (*dynamic.Sticky) {
+	return &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+}
+
 func setLoadbalancerSticky(lb *dynamic.ServersLoadBalancer, val string) error {
 	v, err := strconv.ParseBool(val)
 	if err != nil {
@@ -59,7 +63,7 @@ func setLoadbalancerSticky(lb *dynamic.ServersLoadBalancer, val string) error {
 
 	if v {
 		if lb.Sticky == nil {
-			lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+			lb.Sticky = newSticky()
 		}
 	}
 	return nil
@@ -73,7 +77,7 @@ func setLoadbalancerStickySecure(lb *dynamic.ServersLoadBalancer, val string) er
 
 	if v {
 		if lb.Sticky == nil {
-			lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+			lb.Sticky = newSticky()
 		}
 		lb.Sticky.Cookie.Secure = v
 	}
@@ -88,7 +92,7 @@ func setLoadbalancerStickyHttpOnly(lb *dynamic.ServersLoadBalancer, val string) 
 
 	if v {
 		if lb.Sticky == nil {
-			lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+			lb.Sticky = newSticky()
 		}
 		lb.Sticky.Cookie.HTTPOnly = v
 	}
@@ -97,7 +101,7 @@ func setLoadbalancerStickyHttpOnly(lb *dynamic.ServersLoadBalancer, val string) 
 
 func setLoadbalancerStickySameSite(lb *dynamic.ServersLoadBalancer, val string) error {
 	if lb.Sticky == nil {
-		lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+		lb.Sticky = newSticky()
 	}
 	
 	// Value must be "none", "lax", or "strict".
@@ -113,7 +117,7 @@ func setLoadbalancerStickySameSite(lb *dynamic.ServersLoadBalancer, val string) 
 
 func setLoadbalancerStickyCookieName(lb *dynamic.ServersLoadBalancer, val string) error {
 	if lb.Sticky == nil {
-		lb.Sticky = &dynamic.Sticky{ Cookie: &dynamic.Cookie{} }
+		lb.Sticky = newSticky()
 	}
 	lb.Sticky.Cookie.Name = val
 	return nil

--- a/serviceFabricPlugin.go
+++ b/serviceFabricPlugin.go
@@ -468,7 +468,14 @@ func (p *Provider) processServiceLabels(serviceName string, service *ServiceItem
 				break
 			case "traefik.http.loadbalancer.stickiness":
 				setLoadbalancerSticky(s.LoadBalancer, val)
-				break
+			case "traefik.http.loadbalancer.stickiness.secure":
+				setLoadbalancerStickySecure(s.LoadBalancer, val)
+			case "traefik.http.loadbalancer.stickiness.httpOnly":
+				setLoadbalancerStickyHttpOnly(s.LoadBalancer, val)
+			case "traefik.http.loadbalancer.stickiness.sameSite":
+				setLoadbalancerStickySameSite(s.LoadBalancer, val)
+			case "traefik.http.loadbalancer.stickiness.cookieName":
+				setLoadbalancerStickyCookieName(s.LoadBalancer, val)
 			case "traefik.http.loadbalancer.healthcheck.path":
 				setLoadbalancerHealthcheckPath(s.LoadBalancer, val)
 				break


### PR DESCRIPTION
Fixed #13 by initializing Cookie section of Sticky struct.

Added configuration settings for sticky sessions: Secure, HTTPOnly, SameSite, cookie name.