### PR TITLE
Configurable SF API version and cluster auth certificate trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The plugin needs to be configured in the Traefik static configuration before it 
 The plugin currently supports the following configuration settings:
 * **pollInterval:**          The interval for polling the management endpoint for changes, in seconds.
 * **clusterManagementURL:**  The URL for the Service Fabric Management API endpoint (e.g. `http://dariotraefik1.southcentralus.cloudapp.azure.com:19080/`)
+* **insecureSkipVerify**	 Skip verifying the Service Fabric cluster management certificate trust. Default true.
+* **apiVersion**			 Service Fabric API version to use. Default 3.0.
 * **certificate:**           The path to a certificate file or the PEM certificate content. If not provided, HTTP will be used.
 * **certificateKey:**        The path to a private key file or the key content. If not provided, HTTP will be used.
 
@@ -39,6 +41,8 @@ providers:
     traefikServiceFabricPlugin:
       pollInterval: 4s
       clusterManagementURL: http://dariotraefik1.southcentralus.cloudapp.azure.com:19080/
+	  insecureSkipVerify: true
+	  apiVersion: 6.0
       #certificate : ./cert.pem
       #certificateKey: ./cert.key
 ```

--- a/serviceFabricPlugin.go
+++ b/serviceFabricPlugin.go
@@ -32,6 +32,8 @@ const (
 type Config struct {
 	PollInterval         string `json:"pollInterval,omitempty"`
 	ClusterManagementURL string `json:"clusterManagementURL,omitempty"`
+	InsecureSkipVerify	 *bool  `json:"insecureSkipVerify,omitempty"`
+	APIVersion			 string `json:"apiVersion,omitempty`
 
 	Certificate    string `json:"certificate,omitempty"`
 	CertificateKey string `json:"certificateKey,omitempty"`
@@ -63,10 +65,20 @@ func New(ctx context.Context, config *Config, name string) (*Provider, error) {
 	if err != nil {
 		return nil, err
 	}
+	
+	var sfApiVersion = sf.DefaultAPIVersion
+	if config.APIVersion != "" {
+		sfApiVersion = config.APIVersion
+	}
+	
+	var insecureSkipVerify = true
+	if config.InsecureSkipVerify != nil {
+		insecureSkipVerify = *config.InsecureSkipVerify
+	}
 
 	p := &Provider{
 		name:                 name,
-		apiVersion:           sf.DefaultAPIVersion,
+		apiVersion:           sfApiVersion,
 		pollInterval:         pi,
 		clusterManagementURL: config.ClusterManagementURL,
 	}
@@ -75,7 +87,7 @@ func New(ctx context.Context, config *Config, name string) (*Provider, error) {
 		p.tlsConfig = &ClientTLS{
 			Cert:               config.Certificate,
 			Key:                config.CertificateKey,
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: insecureSkipVerify,
 		}
 	}
 


### PR DESCRIPTION
Made it possible to configure Service Fabric API version used by Traefik plugin. Default is still 3.0, while current newest Service Fabric release is 8.2.

Also it is possible to choose not to trust insecure Service Fabric cluster authentication certificate. Default is still true, to trust insecure certificates.

This functionality matches the functionality of Traefik 1.7 Service Fabric plugin.

Verified that the API version in Traefik calls changes and that insecure certificate is not trusted, when settings are changed.